### PR TITLE
Lock PHPUnit to the v4.* series

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "true/punycode": "~2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4",
+        "phpunit/phpunit": "~4.8",
         "satooshi/php-coveralls": "dev-master",
         "technosophos/PHPCompressor": "dev-master"
     },


### PR DESCRIPTION
Currently, the composer.json would allow any 4.x or 5.x+ versions PHPUnit, however a `composer update` may bring the .lock file to a PHPUnit 5.* version - which only supports PHP v5.6+. That would break the Travis matrix for PHP versions 5.3, 5.4, & 5.5 builds. 

`"phpunit/phpunit":"~4.8"` allows for a non-breaking PHPunit from v4.8, which remains compatible with PHP v5.3+ versions, including PHP v7 & HHVM.